### PR TITLE
chore(dev): config launch "api" — dev API 8787 berdiri sendiri

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -8,6 +8,12 @@
       "port": 5173
     },
     {
+      "name": "api",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["run", "dev:api"],
+      "port": 8787
+    },
+    {
       "name": "dev",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["run", "dev"],


### PR DESCRIPTION
Menambah entri `api` di `.claude/launch.json` (pnpm run dev:api, port 8787), melengkapi `web` dan `dev` yang sudah ada.

Alasan: saat menguji frontend terpisah (mis. layar Dalang Hanoman yang membaca `/api/projects` + WS `sessions`), preview butuh API dev bisa dinyalakan sendiri tanpa memboot pasangan penuh `dev`.

Satu berkas, enam baris, murni konfigurasi tooling dev — tanpa efek runtime produksi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)